### PR TITLE
fix cannot index into null array error

### DIFF
--- a/POSHTools/Public/Clear-VHDXProfile.ps1
+++ b/POSHTools/Public/Clear-VHDXProfile.ps1
@@ -45,16 +45,17 @@ Function Clear-VHDXProfile
 
         foreach ($VHDXFile in $VHDXFiles)
         {
-            $VHDXFile -match '(S-.*).vhdx'
-            $VHDXUid = $Matches[1]
-            Write-Verbose ('[{0:O}] Convert {1} to AD User' -f (Get-Date), $VHDXUid)
-            try {
-                $ADUser = Convert-User2SID -SID $VHDXUid
-                Write-Verbose ('[{0:O}] {1} found in AD => nothing to do !' -f (get-date),$ADUser)
-            }
-            catch {
-                Write-Warning ('[{0:O}] {1} not found in AD => delete vhdx profile !' -f (get-date),$VHDXUid)
-                remove-item -path $VHDXFile -force -Confirm:$false
+            if ($VHDXFile -match '(S-.*).vhdx') {
+                $VHDXUid = $Matches[1]
+                Write-Verbose ('[{0:O}] Convert {1} to AD User' -f (Get-Date), $VHDXUid)
+                try {
+                    $ADUser = Convert-User2SID -SID $VHDXUid
+                    Write-Verbose ('[{0:O}] {1} found in AD => nothing to do !' -f (get-date),$ADUser)
+                }
+                catch {
+                    Write-Warning ('[{0:O}] {1} not found in AD => delete vhdx profile !' -f (get-date),$VHDXUid)
+                    remove-item -path $VHDXFile -force -Confirm:$false
+                }
             }
         }
     }


### PR DESCRIPTION
previously `$matches[1]` would error if there is a vhdx file present that did not match the regex, such as `test.vhdx` or `username_bak.vhdx`:

```
❯ Clear-VHDXProfile -Path .\TESTDIR\ -Verbose
VERBOSE: [2021-10-15T22:02:48.2709392+02:00] Starting Clear-VHDXProfile
VERBOSE: [2021-10-15T22:02:48.2714617+02:00] Retrieve all vhdx files from .\TESTDIR\
VERBOSE: [2021-10-15T22:02:48.2740953+02:00] 1 files retrieve
False
InvalidOperation: C:\POSHTools\POSHTools\Public\Clear-VHDXProfile.ps1:49
Line |
  49 |              $VHDXUid = $Matches[1]
     |              ~~~~~~~~~~~~~~~~~~~~~~
     | Cannot index into a null array.

VERBOSE: [2021-10-15T22:02:48.3592138+02:00] Convert  to AD User
WARNING: [2021-10-15T22:02:48.4009267+02:00]  not found in AD => delete vhdx profile !
VERBOSE: [2021-10-15T22:02:48.4027832+02:00] Ending Clear-VHDXProfile
```

this fixes thata